### PR TITLE
Improve tablet responsive design and add contact buttons

### DIFF
--- a/src/pages/MisCitas.tsx
+++ b/src/pages/MisCitas.tsx
@@ -602,7 +602,7 @@ export default function MisCitas() {
                                       onClick={() => {
                                         window.open(`tel:+51987654321`, '_self');
                                       }}
-                                      className="border-green-300 text-green-700 hover:bg-green-50 w-full sm:w-auto"
+                                      className="border-blue-300 text-blue-700 hover:bg-blue-50 hover:border-blue-400 transition-all duration-200 w-full sm:w-auto shadow-sm"
                                     >
                                       <Phone className="w-4 h-4 mr-2" />
                                       Llamar
@@ -612,7 +612,7 @@ export default function MisCitas() {
                                       onClick={() => {
                                         window.open(`https://wa.me/51987654321?text=Hola, tengo una consulta sobre mi cita con ${cita.mascota} programada para el ${cita.fecha.toLocaleDateString('es-ES')}`, '_blank');
                                       }}
-                                      className="border-green-300 text-green-700 hover:bg-green-50 w-full sm:w-auto"
+                                      className="border-green-400 text-green-700 hover:bg-green-50 hover:border-green-500 bg-green-25 transition-all duration-200 w-full sm:w-auto shadow-sm"
                                     >
                                       <MessageCircle className="w-4 h-4 mr-2" />
                                       WhatsApp

--- a/src/pages/MisCitas.tsx
+++ b/src/pages/MisCitas.tsx
@@ -594,6 +594,31 @@ export default function MisCitas() {
                                     Eliminar Cita
                                   </Button>
                                 )}
+                                {/* Botones de contacto para citas en validación */}
+                                {cita.estado === "en_validacion" && (
+                                  <>
+                                    <Button
+                                      variant="outline"
+                                      onClick={() => {
+                                        window.open(`tel:+51987654321`, '_self');
+                                      }}
+                                      className="border-green-300 text-green-700 hover:bg-green-50 w-full sm:w-auto"
+                                    >
+                                      <Phone className="w-4 h-4 mr-2" />
+                                      Llamar
+                                    </Button>
+                                    <Button
+                                      variant="outline"
+                                      onClick={() => {
+                                        window.open(`https://wa.me/51987654321?text=Hola, tengo una consulta sobre mi cita con ${cita.mascota} programada para el ${cita.fecha.toLocaleDateString('es-ES')}`, '_blank');
+                                      }}
+                                      className="border-green-300 text-green-700 hover:bg-green-50 w-full sm:w-auto"
+                                    >
+                                      <MessageCircle className="w-4 h-4 mr-2" />
+                                      WhatsApp
+                                    </Button>
+                                  </>
+                                )}
                                 {cita.estado === "atendida" && (
                                   <Button
                                     variant="outline"

--- a/src/pages/MisCitas.tsx
+++ b/src/pages/MisCitas.tsx
@@ -604,7 +604,10 @@ export default function MisCitas() {
                                     <Button
                                       variant="outline"
                                       onClick={() => {
-                                        window.open(`tel:+51987654321`, '_self');
+                                        window.open(
+                                          `tel:+51987654321`,
+                                          "_self",
+                                        );
                                       }}
                                       className="border-blue-300 text-blue-700 hover:bg-blue-50 hover:border-blue-400 transition-all duration-200 w-full sm:w-auto shadow-sm"
                                     >
@@ -614,7 +617,10 @@ export default function MisCitas() {
                                     <Button
                                       variant="outline"
                                       onClick={() => {
-                                        window.open(`https://wa.me/51987654321?text=Hola, tengo una consulta sobre mi cita con ${cita.mascota} programada para el ${cita.fecha.toLocaleDateString('es-ES')}`, '_blank');
+                                        window.open(
+                                          `https://wa.me/51987654321?text=Hola, tengo una consulta sobre mi cita con ${cita.mascota} programada para el ${cita.fecha.toLocaleDateString("es-ES")}`,
+                                          "_blank",
+                                        );
                                       }}
                                       className="border-green-400 text-green-700 hover:bg-green-50 hover:border-green-500 bg-green-25 transition-all duration-200 w-full sm:w-auto shadow-sm"
                                     >

--- a/src/pages/MisCitas.tsx
+++ b/src/pages/MisCitas.tsx
@@ -426,7 +426,7 @@ export default function MisCitas() {
                   >
                     <CardContent className="p-4 sm:p-6">
                       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between space-y-4 sm:space-y-0">
-                        <div className="flex items-center space-x-4">
+                        <div className="flex items-center space-x-4 md:space-x-6">
                           {(() => {
                             const mascota = mascotas.find(
                               (m) => m.nombre === cita.mascota,
@@ -435,21 +435,21 @@ export default function MisCitas() {
                               <img
                                 src={mascota.foto}
                                 alt={cita.mascota}
-                                className="w-16 h-16 rounded-full object-cover border-2 border-vet-primary/20"
+                                className="w-16 h-16 md:w-20 md:h-20 lg:w-24 lg:h-24 rounded-full object-cover border-2 border-vet-primary/20"
                               />
                             ) : (
-                              <div className="w-16 h-16 bg-vet-primary/10 rounded-full flex items-center justify-center">
-                                <PawPrint className="w-8 h-8 text-vet-primary" />
+                              <div className="w-16 h-16 md:w-20 md:h-20 lg:w-24 lg:h-24 bg-vet-primary/10 rounded-full flex items-center justify-center">
+                                <PawPrint className="w-8 h-8 md:w-10 md:h-10 lg:w-12 lg:h-12 text-vet-primary" />
                               </div>
                             );
                           })()}
                           <div>
                             <div className="flex flex-col sm:flex-row sm:items-center space-y-2 sm:space-y-0 sm:space-x-2 mb-2">
-                              <h4 className="font-semibold text-base sm:text-lg text-vet-gray-900">
+                              <h4 className="font-semibold text-base sm:text-lg md:text-xl text-vet-gray-900">
                                 {cita.mascota}
                               </h4>
                               <div className="flex space-x-2">
-                                <Badge className="text-xs sm:text-sm">
+                                <Badge className="text-xs sm:text-sm md:text-base">
                                   {cita.especie}
                                 </Badge>
                                 <Badge className={estadoColors[cita.estado]}>
@@ -470,9 +470,9 @@ export default function MisCitas() {
                                 • {cita.veterinario}
                               </span>
                             </p>
-                            <div className="flex flex-col sm:flex-row sm:items-center space-y-2 sm:space-y-0 sm:space-x-6 text-sm sm:text-base text-vet-gray-500">
+                            <div className="flex flex-col sm:flex-row sm:items-center space-y-2 sm:space-y-0 sm:space-x-6 md:space-x-8 text-sm sm:text-base md:text-lg text-vet-gray-500">
                               <div className="flex items-center space-x-2">
-                                <Calendar className="w-5 h-5 sm:w-4 sm:h-4 text-vet-primary" />
+                                <Calendar className="w-5 h-5 sm:w-4 sm:h-4 md:w-5 md:h-5 text-vet-primary" />
                                 <span className="font-medium">
                                   {cita.fecha.toLocaleDateString("es-ES", {
                                     weekday: "short",
@@ -482,7 +482,7 @@ export default function MisCitas() {
                                 </span>
                               </div>
                               <div className="flex items-center space-x-2">
-                                <Clock className="w-5 h-5 sm:w-4 sm:h-4 text-vet-primary" />
+                                <Clock className="w-5 h-5 sm:w-4 sm:h-4 md:w-5 md:h-5 text-vet-primary" />
                                 <span className="font-medium">
                                   {cita.fecha.toLocaleTimeString("es-ES", {
                                     hour: "2-digit",
@@ -491,7 +491,7 @@ export default function MisCitas() {
                                 </span>
                               </div>
                               <div className="flex items-center space-x-2">
-                                <MapPin className="w-5 h-5 sm:w-4 sm:h-4 text-vet-primary" />
+                                <MapPin className="w-5 h-5 sm:w-4 sm:h-4 md:w-5 md:h-5 text-vet-primary" />
                                 <span className="font-medium">
                                   {cita.ubicacion}
                                 </span>

--- a/src/pages/MisCitas.tsx
+++ b/src/pages/MisCitas.tsx
@@ -470,28 +470,32 @@ export default function MisCitas() {
                                 • {cita.veterinario}
                               </span>
                             </p>
-                            <div className="flex flex-col sm:flex-row sm:items-center space-y-2 sm:space-y-0 sm:space-x-6 md:space-x-10 text-sm sm:text-base md:text-lg text-vet-gray-500">
-                              <div className="flex items-center space-x-2">
-                                <Calendar className="w-6 h-6 sm:w-5 sm:h-5 md:w-8 md:h-8 lg:w-6 lg:h-6 text-vet-primary" />
-                                <span className="font-medium">
-                                  {cita.fecha.toLocaleDateString("es-ES", {
-                                    weekday: "short",
-                                    month: "short",
-                                    day: "numeric",
-                                  })}
-                                </span>
+                            <div className="space-y-2">
+                              {/* Fecha y Hora en una línea */}
+                              <div className="flex items-center space-x-4 md:space-x-6 text-sm sm:text-base md:text-lg text-vet-gray-500">
+                                <div className="flex items-center space-x-2">
+                                  <Calendar className="w-5 h-5 md:w-6 md:h-6 text-vet-primary" />
+                                  <span className="font-medium">
+                                    {cita.fecha.toLocaleDateString("es-ES", {
+                                      weekday: "short",
+                                      month: "short",
+                                      day: "numeric",
+                                    })}
+                                  </span>
+                                </div>
+                                <div className="flex items-center space-x-2">
+                                  <Clock className="w-5 h-5 md:w-6 md:h-6 text-vet-primary" />
+                                  <span className="font-medium">
+                                    {cita.fecha.toLocaleTimeString("es-ES", {
+                                      hour: "2-digit",
+                                      minute: "2-digit",
+                                    })}
+                                  </span>
+                                </div>
                               </div>
-                              <div className="flex items-center space-x-2">
-                                <Clock className="w-6 h-6 sm:w-5 sm:h-5 md:w-8 md:h-8 lg:w-6 lg:h-6 text-vet-primary" />
-                                <span className="font-medium">
-                                  {cita.fecha.toLocaleTimeString("es-ES", {
-                                    hour: "2-digit",
-                                    minute: "2-digit",
-                                  })}
-                                </span>
-                              </div>
-                              <div className="flex items-center space-x-2">
-                                <MapPin className="w-6 h-6 sm:w-5 sm:h-5 md:w-8 md:h-8 lg:w-6 lg:h-6 text-vet-primary" />
+                              {/* Clínica en línea separada */}
+                              <div className="flex items-center space-x-2 text-sm sm:text-base md:text-lg text-vet-gray-500">
+                                <MapPin className="w-5 h-5 md:w-6 md:h-6 text-vet-primary" />
                                 <span className="font-medium">
                                   {cita.ubicacion}
                                 </span>

--- a/src/pages/MisCitas.tsx
+++ b/src/pages/MisCitas.tsx
@@ -578,7 +578,7 @@ export default function MisCitas() {
                                     <Button
                                       variant="outline"
                                       onClick={() => handleViewReceipt(cita.id)}
-                                      className="border-vet-primary text-vet-primary hover:bg-vet-primary/10 w-full sm:w-auto"
+                                      className="border-vet-primary text-vet-primary hover:bg-vet-primary/10 hover:border-vet-primary-dark transition-all duration-200 w-full sm:w-auto shadow-sm"
                                     >
                                       <Eye className="w-4 h-4 mr-2" />
                                       Ver Comprobante

--- a/src/pages/MisCitas.tsx
+++ b/src/pages/MisCitas.tsx
@@ -435,21 +435,21 @@ export default function MisCitas() {
                               <img
                                 src={mascota.foto}
                                 alt={cita.mascota}
-                                className="w-20 h-20 md:w-52 md:h-52 lg:w-28 lg:h-28 rounded-full object-cover border-2 border-vet-primary/30 flex-shrink-0"
+                                className="w-20 h-20 md:w-32 md:h-32 lg:w-28 lg:h-28 rounded-full object-cover border-2 border-vet-primary/30 flex-shrink-0"
                               />
                             ) : (
-                              <div className="w-20 h-20 md:w-52 md:h-52 lg:w-28 lg:h-28 bg-vet-primary/10 rounded-full flex items-center justify-center flex-shrink-0">
-                                <PawPrint className="w-10 h-10 md:w-26 md:h-26 lg:w-14 lg:h-14 text-vet-primary" />
+                              <div className="w-20 h-20 md:w-32 md:h-32 lg:w-28 lg:h-28 bg-vet-primary/10 rounded-full flex items-center justify-center flex-shrink-0">
+                                <PawPrint className="w-10 h-10 md:w-16 md:h-16 lg:w-14 lg:h-14 text-vet-primary" />
                               </div>
                             );
                           })()}
                           <div>
                             <div className="flex flex-col sm:flex-row sm:items-center space-y-2 sm:space-y-0 sm:space-x-2 mb-2">
-                              <h4 className="font-semibold text-base sm:text-lg md:text-xl text-vet-gray-900">
+                              <h4 className="font-semibold text-base sm:text-lg md:text-2xl text-vet-gray-900">
                                 {cita.mascota}
                               </h4>
                               <div className="flex space-x-2">
-                                <Badge className="text-xs sm:text-sm md:text-base">
+                                <Badge className="text-xs sm:text-sm md:text-lg">
                                   {cita.especie}
                                 </Badge>
                                 <Badge className={estadoColors[cita.estado]}>
@@ -457,7 +457,7 @@ export default function MisCitas() {
                                 </Badge>
                               </div>
                             </div>
-                            <p className="text-sm sm:text-base text-vet-gray-600 mb-3">
+                            <p className="text-sm sm:text-base md:text-xl text-vet-gray-600 mb-3">
                               <span className="font-medium text-vet-primary">
                                 {cita.tipoConsulta}
                               </span>
@@ -470,9 +470,9 @@ export default function MisCitas() {
                                 • {cita.veterinario}
                               </span>
                             </p>
-                            <div className="flex flex-col sm:flex-row sm:items-center space-y-2 sm:space-y-0 sm:space-x-6 md:space-x-8 text-sm sm:text-base md:text-lg text-vet-gray-500">
+                            <div className="flex flex-col sm:flex-row sm:items-center space-y-2 sm:space-y-0 sm:space-x-6 md:space-x-10 text-sm sm:text-base md:text-lg text-vet-gray-500">
                               <div className="flex items-center space-x-2">
-                                <Calendar className="w-6 h-6 sm:w-5 sm:h-5 md:w-24 md:h-24 lg:w-6 lg:h-6 text-vet-primary" />
+                                <Calendar className="w-6 h-6 sm:w-5 sm:h-5 md:w-8 md:h-8 lg:w-6 lg:h-6 text-vet-primary" />
                                 <span className="font-medium">
                                   {cita.fecha.toLocaleDateString("es-ES", {
                                     weekday: "short",
@@ -482,7 +482,7 @@ export default function MisCitas() {
                                 </span>
                               </div>
                               <div className="flex items-center space-x-2">
-                                <Clock className="w-6 h-6 sm:w-5 sm:h-5 md:w-24 md:h-24 lg:w-6 lg:h-6 text-vet-primary" />
+                                <Clock className="w-6 h-6 sm:w-5 sm:h-5 md:w-8 md:h-8 lg:w-6 lg:h-6 text-vet-primary" />
                                 <span className="font-medium">
                                   {cita.fecha.toLocaleTimeString("es-ES", {
                                     hour: "2-digit",
@@ -491,7 +491,7 @@ export default function MisCitas() {
                                 </span>
                               </div>
                               <div className="flex items-center space-x-2">
-                                <MapPin className="w-6 h-6 sm:w-5 sm:h-5 md:w-24 md:h-24 lg:w-6 lg:h-6 text-vet-primary" />
+                                <MapPin className="w-6 h-6 sm:w-5 sm:h-5 md:w-8 md:h-8 lg:w-6 lg:h-6 text-vet-primary" />
                                 <span className="font-medium">
                                   {cita.ubicacion}
                                 </span>
@@ -523,10 +523,10 @@ export default function MisCitas() {
                         </div>
 
                         <div className="text-left sm:text-right">
-                          <div className="text-lg sm:text-xl md:text-2xl lg:text-3xl font-bold text-vet-gray-900 mb-2 sm:mb-3 md:mb-4">
+                          <div className="text-lg sm:text-xl md:text-3xl lg:text-3xl font-bold text-vet-gray-900 mb-2 sm:mb-3 md:mb-6">
                             S/. {cita.precio.toLocaleString()}
                           </div>
-                          <div className="flex flex-col sm:flex-col gap-3 md:gap-4">
+                          <div className="flex flex-col sm:flex-col gap-3 md:gap-6">
                             {user?.rol === "veterinario" ? (
                               <>
                                 {cita.estado === "aceptada" && (
@@ -580,7 +580,7 @@ export default function MisCitas() {
                                       onClick={() => handleViewReceipt(cita.id)}
                                       className="border-vet-primary text-vet-primary hover:bg-vet-primary/10 hover:border-vet-primary-dark transition-all duration-200 w-full sm:w-auto shadow-sm"
                                     >
-                                      <Eye className="w-5 h-5 md:w-6 md:h-6 mr-2" />
+                                      <Eye className="w-5 h-5 md:w-7 md:h-7 mr-2" />
                                       Ver Comprobante
                                     </Button>
                                   )}
@@ -604,7 +604,7 @@ export default function MisCitas() {
                                       }}
                                       className="border-blue-300 text-blue-700 hover:bg-blue-50 hover:border-blue-400 transition-all duration-200 w-full sm:w-auto shadow-sm"
                                     >
-                                      <Phone className="w-5 h-5 md:w-6 md:h-6 mr-2" />
+                                      <Phone className="w-5 h-5 md:w-7 md:h-7 mr-2" />
                                       Llamar
                                     </Button>
                                     <Button
@@ -614,7 +614,7 @@ export default function MisCitas() {
                                       }}
                                       className="border-green-400 text-green-700 hover:bg-green-50 hover:border-green-500 bg-green-25 transition-all duration-200 w-full sm:w-auto shadow-sm"
                                     >
-                                      <MessageCircle className="w-5 h-5 md:w-6 md:h-6 mr-2" />
+                                      <MessageCircle className="w-5 h-5 md:w-7 md:h-7 mr-2" />
                                       WhatsApp
                                     </Button>
                                   </>

--- a/src/pages/MisCitas.tsx
+++ b/src/pages/MisCitas.tsx
@@ -435,11 +435,11 @@ export default function MisCitas() {
                               <img
                                 src={mascota.foto}
                                 alt={cita.mascota}
-                                className="w-24 h-24 md:w-36 md:h-36 lg:w-40 lg:h-40 rounded-full object-cover border-2 border-vet-primary/20"
+                                className="w-28 h-28 md:w-44 md:h-44 lg:w-48 lg:h-48 rounded-full object-cover border-3 border-vet-primary/30 flex-shrink-0"
                               />
                             ) : (
-                              <div className="w-24 h-24 md:w-36 md:h-36 lg:w-40 lg:h-40 bg-vet-primary/10 rounded-full flex items-center justify-center">
-                                <PawPrint className="w-12 h-12 md:w-18 md:h-18 lg:w-20 lg:h-20 text-vet-primary" />
+                              <div className="w-28 h-28 md:w-44 md:h-44 lg:w-48 lg:h-48 bg-vet-primary/10 rounded-full flex items-center justify-center flex-shrink-0">
+                                <PawPrint className="w-14 h-14 md:w-22 md:h-22 lg:w-24 lg:h-24 text-vet-primary" />
                               </div>
                             );
                           })()}
@@ -472,7 +472,7 @@ export default function MisCitas() {
                             </p>
                             <div className="flex flex-col sm:flex-row sm:items-center space-y-2 sm:space-y-0 sm:space-x-6 md:space-x-8 text-sm sm:text-base md:text-lg text-vet-gray-500">
                               <div className="flex items-center space-x-2">
-                                <Calendar className="w-7 h-7 sm:w-6 sm:h-6 md:w-9 md:h-9 lg:w-8 lg:h-8 text-vet-primary" />
+                                <Calendar className="w-8 h-8 sm:w-7 sm:h-7 md:w-12 md:h-12 lg:w-10 lg:h-10 text-vet-primary" />
                                 <span className="font-medium">
                                   {cita.fecha.toLocaleDateString("es-ES", {
                                     weekday: "short",
@@ -482,7 +482,7 @@ export default function MisCitas() {
                                 </span>
                               </div>
                               <div className="flex items-center space-x-2">
-                                <Clock className="w-7 h-7 sm:w-6 sm:h-6 md:w-9 md:h-9 lg:w-8 lg:h-8 text-vet-primary" />
+                                <Clock className="w-8 h-8 sm:w-7 sm:h-7 md:w-12 md:h-12 lg:w-10 lg:h-10 text-vet-primary" />
                                 <span className="font-medium">
                                   {cita.fecha.toLocaleTimeString("es-ES", {
                                     hour: "2-digit",
@@ -491,7 +491,7 @@ export default function MisCitas() {
                                 </span>
                               </div>
                               <div className="flex items-center space-x-2">
-                                <MapPin className="w-7 h-7 sm:w-6 sm:h-6 md:w-9 md:h-9 lg:w-8 lg:h-8 text-vet-primary" />
+                                <MapPin className="w-8 h-8 sm:w-7 sm:h-7 md:w-12 md:h-12 lg:w-10 lg:h-10 text-vet-primary" />
                                 <span className="font-medium">
                                   {cita.ubicacion}
                                 </span>

--- a/src/pages/MisCitas.tsx
+++ b/src/pages/MisCitas.tsx
@@ -435,11 +435,11 @@ export default function MisCitas() {
                               <img
                                 src={mascota.foto}
                                 alt={cita.mascota}
-                                className="w-20 h-20 md:w-28 md:h-28 lg:w-32 lg:h-32 rounded-full object-cover border-2 border-vet-primary/20"
+                                className="w-24 h-24 md:w-36 md:h-36 lg:w-40 lg:h-40 rounded-full object-cover border-2 border-vet-primary/20"
                               />
                             ) : (
-                              <div className="w-20 h-20 md:w-28 md:h-28 lg:w-32 lg:h-32 bg-vet-primary/10 rounded-full flex items-center justify-center">
-                                <PawPrint className="w-10 h-10 md:w-14 md:h-14 lg:w-16 lg:h-16 text-vet-primary" />
+                              <div className="w-24 h-24 md:w-36 md:h-36 lg:w-40 lg:h-40 bg-vet-primary/10 rounded-full flex items-center justify-center">
+                                <PawPrint className="w-12 h-12 md:w-18 md:h-18 lg:w-20 lg:h-20 text-vet-primary" />
                               </div>
                             );
                           })()}
@@ -472,7 +472,7 @@ export default function MisCitas() {
                             </p>
                             <div className="flex flex-col sm:flex-row sm:items-center space-y-2 sm:space-y-0 sm:space-x-6 md:space-x-8 text-sm sm:text-base md:text-lg text-vet-gray-500">
                               <div className="flex items-center space-x-2">
-                                <Calendar className="w-6 h-6 sm:w-5 sm:h-5 md:w-7 md:h-7 lg:w-6 lg:h-6 text-vet-primary" />
+                                <Calendar className="w-7 h-7 sm:w-6 sm:h-6 md:w-9 md:h-9 lg:w-8 lg:h-8 text-vet-primary" />
                                 <span className="font-medium">
                                   {cita.fecha.toLocaleDateString("es-ES", {
                                     weekday: "short",
@@ -482,7 +482,7 @@ export default function MisCitas() {
                                 </span>
                               </div>
                               <div className="flex items-center space-x-2">
-                                <Clock className="w-6 h-6 sm:w-5 sm:h-5 md:w-7 md:h-7 lg:w-6 lg:h-6 text-vet-primary" />
+                                <Clock className="w-7 h-7 sm:w-6 sm:h-6 md:w-9 md:h-9 lg:w-8 lg:h-8 text-vet-primary" />
                                 <span className="font-medium">
                                   {cita.fecha.toLocaleTimeString("es-ES", {
                                     hour: "2-digit",
@@ -491,7 +491,7 @@ export default function MisCitas() {
                                 </span>
                               </div>
                               <div className="flex items-center space-x-2">
-                                <MapPin className="w-6 h-6 sm:w-5 sm:h-5 md:w-7 md:h-7 lg:w-6 lg:h-6 text-vet-primary" />
+                                <MapPin className="w-7 h-7 sm:w-6 sm:h-6 md:w-9 md:h-9 lg:w-8 lg:h-8 text-vet-primary" />
                                 <span className="font-medium">
                                   {cita.ubicacion}
                                 </span>
@@ -580,7 +580,7 @@ export default function MisCitas() {
                                       onClick={() => handleViewReceipt(cita.id)}
                                       className="border-vet-primary text-vet-primary hover:bg-vet-primary/10 hover:border-vet-primary-dark transition-all duration-200 w-full sm:w-auto shadow-sm"
                                     >
-                                      <Eye className="w-4 h-4 mr-2" />
+                                      <Eye className="w-5 h-5 md:w-6 md:h-6 mr-2" />
                                       Ver Comprobante
                                     </Button>
                                   )}
@@ -604,7 +604,7 @@ export default function MisCitas() {
                                       }}
                                       className="border-blue-300 text-blue-700 hover:bg-blue-50 hover:border-blue-400 transition-all duration-200 w-full sm:w-auto shadow-sm"
                                     >
-                                      <Phone className="w-4 h-4 mr-2" />
+                                      <Phone className="w-5 h-5 md:w-6 md:h-6 mr-2" />
                                       Llamar
                                     </Button>
                                     <Button
@@ -614,7 +614,7 @@ export default function MisCitas() {
                                       }}
                                       className="border-green-400 text-green-700 hover:bg-green-50 hover:border-green-500 bg-green-25 transition-all duration-200 w-full sm:w-auto shadow-sm"
                                     >
-                                      <MessageCircle className="w-4 h-4 mr-2" />
+                                      <MessageCircle className="w-5 h-5 md:w-6 md:h-6 mr-2" />
                                       WhatsApp
                                     </Button>
                                   </>

--- a/src/pages/MisCitas.tsx
+++ b/src/pages/MisCitas.tsx
@@ -526,7 +526,7 @@ export default function MisCitas() {
                           <div className="text-lg sm:text-xl lg:text-2xl font-bold text-vet-gray-900 mb-2 sm:mb-3">
                             S/. {cita.precio.toLocaleString()}
                           </div>
-                          <div className="flex flex-col sm:flex-col gap-2">
+                          <div className="flex flex-col sm:flex-col gap-3">
                             {user?.rol === "veterinario" ? (
                               <>
                                 {cita.estado === "aceptada" && (

--- a/src/pages/MisCitas.tsx
+++ b/src/pages/MisCitas.tsx
@@ -523,10 +523,10 @@ export default function MisCitas() {
                         </div>
 
                         <div className="text-left sm:text-right">
-                          <div className="text-lg sm:text-xl lg:text-2xl font-bold text-vet-gray-900 mb-2 sm:mb-3">
+                          <div className="text-lg sm:text-xl md:text-2xl lg:text-3xl font-bold text-vet-gray-900 mb-2 sm:mb-3 md:mb-4">
                             S/. {cita.precio.toLocaleString()}
                           </div>
-                          <div className="flex flex-col sm:flex-col gap-3">
+                          <div className="flex flex-col sm:flex-col gap-3 md:gap-4">
                             {user?.rol === "veterinario" ? (
                               <>
                                 {cita.estado === "aceptada" && (

--- a/src/pages/MisCitas.tsx
+++ b/src/pages/MisCitas.tsx
@@ -472,7 +472,7 @@ export default function MisCitas() {
                             </p>
                             <div className="flex flex-col sm:flex-row sm:items-center space-y-2 sm:space-y-0 sm:space-x-6 md:space-x-8 text-sm sm:text-base md:text-lg text-vet-gray-500">
                               <div className="flex items-center space-x-2">
-                                <Calendar className="w-6 h-6 sm:w-5 sm:h-5 md:w-16 md:h-16 lg:w-6 lg:h-6 text-vet-primary" />
+                                <Calendar className="w-6 h-6 sm:w-5 sm:h-5 md:w-24 md:h-24 lg:w-6 lg:h-6 text-vet-primary" />
                                 <span className="font-medium">
                                   {cita.fecha.toLocaleDateString("es-ES", {
                                     weekday: "short",
@@ -482,7 +482,7 @@ export default function MisCitas() {
                                 </span>
                               </div>
                               <div className="flex items-center space-x-2">
-                                <Clock className="w-6 h-6 sm:w-5 sm:h-5 md:w-16 md:h-16 lg:w-6 lg:h-6 text-vet-primary" />
+                                <Clock className="w-6 h-6 sm:w-5 sm:h-5 md:w-24 md:h-24 lg:w-6 lg:h-6 text-vet-primary" />
                                 <span className="font-medium">
                                   {cita.fecha.toLocaleTimeString("es-ES", {
                                     hour: "2-digit",
@@ -491,7 +491,7 @@ export default function MisCitas() {
                                 </span>
                               </div>
                               <div className="flex items-center space-x-2">
-                                <MapPin className="w-6 h-6 sm:w-5 sm:h-5 md:w-16 md:h-16 lg:w-6 lg:h-6 text-vet-primary" />
+                                <MapPin className="w-6 h-6 sm:w-5 sm:h-5 md:w-24 md:h-24 lg:w-6 lg:h-6 text-vet-primary" />
                                 <span className="font-medium">
                                   {cita.ubicacion}
                                 </span>

--- a/src/pages/MisCitas.tsx
+++ b/src/pages/MisCitas.tsx
@@ -39,6 +39,7 @@ import {
   AlertCircle,
   Trash2,
   Download,
+  MessageCircle,
 } from "lucide-react";
 
 const estadoColors = {

--- a/src/pages/MisCitas.tsx
+++ b/src/pages/MisCitas.tsx
@@ -435,11 +435,11 @@ export default function MisCitas() {
                               <img
                                 src={mascota.foto}
                                 alt={cita.mascota}
-                                className="w-28 h-28 md:w-44 md:h-44 lg:w-48 lg:h-48 rounded-full object-cover border-3 border-vet-primary/30 flex-shrink-0"
+                                className="w-20 h-20 md:w-52 md:h-52 lg:w-28 lg:h-28 rounded-full object-cover border-2 border-vet-primary/30 flex-shrink-0"
                               />
                             ) : (
-                              <div className="w-28 h-28 md:w-44 md:h-44 lg:w-48 lg:h-48 bg-vet-primary/10 rounded-full flex items-center justify-center flex-shrink-0">
-                                <PawPrint className="w-14 h-14 md:w-22 md:h-22 lg:w-24 lg:h-24 text-vet-primary" />
+                              <div className="w-20 h-20 md:w-52 md:h-52 lg:w-28 lg:h-28 bg-vet-primary/10 rounded-full flex items-center justify-center flex-shrink-0">
+                                <PawPrint className="w-10 h-10 md:w-26 md:h-26 lg:w-14 lg:h-14 text-vet-primary" />
                               </div>
                             );
                           })()}
@@ -472,7 +472,7 @@ export default function MisCitas() {
                             </p>
                             <div className="flex flex-col sm:flex-row sm:items-center space-y-2 sm:space-y-0 sm:space-x-6 md:space-x-8 text-sm sm:text-base md:text-lg text-vet-gray-500">
                               <div className="flex items-center space-x-2">
-                                <Calendar className="w-8 h-8 sm:w-7 sm:h-7 md:w-12 md:h-12 lg:w-10 lg:h-10 text-vet-primary" />
+                                <Calendar className="w-6 h-6 sm:w-5 sm:h-5 md:w-16 md:h-16 lg:w-6 lg:h-6 text-vet-primary" />
                                 <span className="font-medium">
                                   {cita.fecha.toLocaleDateString("es-ES", {
                                     weekday: "short",
@@ -482,7 +482,7 @@ export default function MisCitas() {
                                 </span>
                               </div>
                               <div className="flex items-center space-x-2">
-                                <Clock className="w-8 h-8 sm:w-7 sm:h-7 md:w-12 md:h-12 lg:w-10 lg:h-10 text-vet-primary" />
+                                <Clock className="w-6 h-6 sm:w-5 sm:h-5 md:w-16 md:h-16 lg:w-6 lg:h-6 text-vet-primary" />
                                 <span className="font-medium">
                                   {cita.fecha.toLocaleTimeString("es-ES", {
                                     hour: "2-digit",
@@ -491,7 +491,7 @@ export default function MisCitas() {
                                 </span>
                               </div>
                               <div className="flex items-center space-x-2">
-                                <MapPin className="w-8 h-8 sm:w-7 sm:h-7 md:w-12 md:h-12 lg:w-10 lg:h-10 text-vet-primary" />
+                                <MapPin className="w-6 h-6 sm:w-5 sm:h-5 md:w-16 md:h-16 lg:w-6 lg:h-6 text-vet-primary" />
                                 <span className="font-medium">
                                   {cita.ubicacion}
                                 </span>

--- a/src/pages/MisCitas.tsx
+++ b/src/pages/MisCitas.tsx
@@ -435,11 +435,11 @@ export default function MisCitas() {
                               <img
                                 src={mascota.foto}
                                 alt={cita.mascota}
-                                className="w-16 h-16 md:w-20 md:h-20 lg:w-24 lg:h-24 rounded-full object-cover border-2 border-vet-primary/20"
+                                className="w-20 h-20 md:w-28 md:h-28 lg:w-32 lg:h-32 rounded-full object-cover border-2 border-vet-primary/20"
                               />
                             ) : (
-                              <div className="w-16 h-16 md:w-20 md:h-20 lg:w-24 lg:h-24 bg-vet-primary/10 rounded-full flex items-center justify-center">
-                                <PawPrint className="w-8 h-8 md:w-10 md:h-10 lg:w-12 lg:h-12 text-vet-primary" />
+                              <div className="w-20 h-20 md:w-28 md:h-28 lg:w-32 lg:h-32 bg-vet-primary/10 rounded-full flex items-center justify-center">
+                                <PawPrint className="w-10 h-10 md:w-14 md:h-14 lg:w-16 lg:h-16 text-vet-primary" />
                               </div>
                             );
                           })()}
@@ -472,7 +472,7 @@ export default function MisCitas() {
                             </p>
                             <div className="flex flex-col sm:flex-row sm:items-center space-y-2 sm:space-y-0 sm:space-x-6 md:space-x-8 text-sm sm:text-base md:text-lg text-vet-gray-500">
                               <div className="flex items-center space-x-2">
-                                <Calendar className="w-5 h-5 sm:w-4 sm:h-4 md:w-5 md:h-5 text-vet-primary" />
+                                <Calendar className="w-6 h-6 sm:w-5 sm:h-5 md:w-7 md:h-7 lg:w-6 lg:h-6 text-vet-primary" />
                                 <span className="font-medium">
                                   {cita.fecha.toLocaleDateString("es-ES", {
                                     weekday: "short",
@@ -482,7 +482,7 @@ export default function MisCitas() {
                                 </span>
                               </div>
                               <div className="flex items-center space-x-2">
-                                <Clock className="w-5 h-5 sm:w-4 sm:h-4 md:w-5 md:h-5 text-vet-primary" />
+                                <Clock className="w-6 h-6 sm:w-5 sm:h-5 md:w-7 md:h-7 lg:w-6 lg:h-6 text-vet-primary" />
                                 <span className="font-medium">
                                   {cita.fecha.toLocaleTimeString("es-ES", {
                                     hour: "2-digit",
@@ -491,7 +491,7 @@ export default function MisCitas() {
                                 </span>
                               </div>
                               <div className="flex items-center space-x-2">
-                                <MapPin className="w-5 h-5 sm:w-4 sm:h-4 md:w-5 md:h-5 text-vet-primary" />
+                                <MapPin className="w-6 h-6 sm:w-5 sm:h-5 md:w-7 md:h-7 lg:w-6 lg:h-6 text-vet-primary" />
                                 <span className="font-medium">
                                   {cita.ubicacion}
                                 </span>


### PR DESCRIPTION
## Purpose

The user requested improvements to the appointment card design with focus on tablet responsiveness. Key requirements included:
- Adding contact buttons (call/WhatsApp) that appear when client uploads payment receipt and disappear after veterinarian attention
- Improving button design with different colors to avoid visual confusion
- Fixing tablet responsive issues where icons and pet images appeared too small
- Reorganizing date/time and clinic information layout for better tablet display

## Code changes

- **Enhanced tablet responsiveness**: Increased icon sizes (`w-5 h-5 md:w-6 md:h-6`) and pet image dimensions (`w-20 h-20 md:w-32 md:h-32`) specifically for tablet breakpoint
- **Improved layout structure**: Reorganized date/time and clinic information - date and time now display on same line, clinic information on separate line below
- **Added contact functionality**: Implemented call and WhatsApp buttons that appear for appointments in "en_validacion" status
- **Enhanced button styling**: Applied distinct color schemes - blue for call button, green for WhatsApp, with improved hover states and shadows
- **Typography scaling**: Added responsive text sizing (`md:text-lg`, `md:text-xl`) for better tablet readability
- **Spacing improvements**: Increased gaps and margins (`md:gap-6`, `md:space-x-6`) for better tablet layout

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 15`

🔗 [Edit in Builder.io](https://builder.io/app/projects/cc845f4bd93d45a1bd13ba62939d3c05/nova-sanctuary)

👀 [Preview Link](https://cc845f4bd93d45a1bd13ba62939d3c05-nova-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>cc845f4bd93d45a1bd13ba62939d3c05</projectId>-->
<!--<branchName>nova-sanctuary</branchName>-->